### PR TITLE
fix copy command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           npm install
           npm run build
           mkdir ${{ env.PLUGIN_NAME }}
-          cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
+          cp dist/main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
           zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
           ls
           echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "word-frequency",
   "name": "Word Frequency",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "minAppVersion": "1.0.0",
   "description": "Counts the most frequently used words in a note and displays them in the sidebar with pagination.",
   "author": "Mike Rodarte",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-frequency",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "description": "Count word frequency in current note within Obsidian",
   "main": "main.js",


### PR DESCRIPTION
The copy command did not specify the `dist` directory for the `main.js` file, causing errors in the build script.