### PR TITLE
add support for multiple languages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ export default [
             'coverage/**',
             'dist/**',
             'node_modules/**',
+            'reports/**',
             '.stryker-tmp/**',
         ],
     },
@@ -45,6 +46,12 @@ export default [
                 'error',
                 { argsIgnorePattern: '^_' },
             ],
+        },
+    },
+    {
+        files: ['**/*.d.ts'],
+        rules: {
+            'no-unused-vars': 'off',
         },
     },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,10 +48,4 @@ export default [
             ],
         },
     },
-    {
-        files: ['**/*.d.ts'],
-        rules: {
-            'no-unused-vars': 'off',
-        },
-    },
 ];

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "word-frequency",
   "name": "Word Frequency",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "minAppVersion": "1.0.0",
   "description": "Counts the most frequently used words in a note and displays them in the sidebar.",
   "author": "Mike Rodarte",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "word-frequency",
-  "version": "1.3.0",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "word-frequency",
-      "version": "1.3.0",
+      "version": "1.3.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.22.0",
-        "@rollup/plugin-commonjs": "^28.0.2",
+        "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-typescript": "^12.1.2",
@@ -18,6 +18,7 @@
         "@stryker-mutator/jest-runner": "^8.7.1",
         "@types/jest": "^29.5.14",
         "@types/jsdom": "^21.1.7",
+        "@types/kuromoji": "^0.1.3",
         "@types/node": "^22.13.9",
         "@typescript-eslint/eslint-plugin": "^8.26.1",
         "@typescript-eslint/parser": "^8.26.1",
@@ -25,17 +26,22 @@
         "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.11.0",
+        "franc": "^6.2.0",
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jieba-js": "^1.0.2",
         "jsdom": "^26.0.0",
+        "kuromoji": "^0.1.2",
         "obsidian": "^1.8.7",
         "prettier": "^3.5.3",
         "rollup": "^4.34.9",
         "rollup-plugin-typescript2": "^0.36.0",
+        "segmentit": "^2.0.3",
         "ts-jest": "^29.2.6",
         "typescript": "^5.8.2",
-        "typescript-eslint": "^8.26.1"
+        "typescript-eslint": "^8.26.1",
+        "wordcut": "^0.9.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -685,6 +691,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1725,9 +1740,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.2.tgz",
-      "integrity": "sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==",
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.3.tgz",
+      "integrity": "sha512-pyltgilam1QPdn+Zd9gaCfOLcnjMEJ9gV+bTw6/r73INdvzf1ah9zLIJBm+kW7R6IUFIQ1YO+VqZtYxZNWFPEQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -2736,6 +2751,12 @@
         "@types/tern": "*"
       }
     },
+    "node_modules/@types/doublearray": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/doublearray/-/doublearray-0.0.32.tgz",
+      "integrity": "sha512-HloTru3I3a55runIVqZX1YBQi2L5A4peNQPh33yshzB4ttt1qHCnHPkuhy9Djy/cTx7i5xJvxItKRPCmvnfpGw==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2808,6 +2829,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/kuromoji": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/kuromoji/-/kuromoji-0.1.3.tgz",
+      "integrity": "sha512-u+YwX6eJj6Fmm0F5qunsyA+X8HSiyRNNE5ON3itD3tERax4meq9tv+S7bjTMXkPjqbdBGUmH2maGDCuEvpODwg==",
+      "dev": true,
+      "dependencies": {
+        "@types/doublearray": "*"
+      }
+    },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
@@ -2825,6 +2855,12 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -3444,6 +3480,65 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-preval": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-4.0.0.tgz",
+      "integrity": "sha512-fZI/4cYneinlj2k/FsXw0/lTWSC5KKoepUueS1g25Gb5vx3GrRyaVwxWCshYqx11GEU4mZnbbFhee8vpquFS2w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "babel-plugin-macros": "^2.6.1",
+        "require-from-string": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-preval/node_modules/babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
+    "node_modules/babel-plugin-preval/node_modules/cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
@@ -3491,6 +3586,18 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/body": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+      "integrity": "sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==",
+      "dev": true,
+      "dependencies": {
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3571,6 +3678,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==",
       "dev": true
     },
     "node_modules/call-bind": {
@@ -3743,6 +3856,16 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -3800,11 +3923,41 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/continuable-cache": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+      "integrity": "sha512-TF30kpKhTH8AGCG3dut0rdd/19B7Z+qCnrMoBLpyQu/2drZdNrrpcjPEoJeSVsQM+8KmWG5O56oPDjSSUsuTyA==",
+      "dev": true
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA==",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -3825,6 +3978,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/crlf-normalize": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/crlf-normalize/-/crlf-normalize-1.0.20.tgz",
+      "integrity": "sha512-h/rBerTd3YHQGfv7tNT25mfhWvRq2BBLCZZ80GFarFxf6HQGbpW6iqDL3N+HBLpjLfAdcBXfWAzVlLfHkRUQBQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-type": ">=2"
       }
     },
     "node_modules/cross-spawn": {
@@ -4078,6 +4240,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "dev": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4141,6 +4309,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
+      "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
+      "dev": true,
+      "dependencies": {
+        "string-template": "~0.2.1"
       }
     },
     "node_modules/error-ex": {
@@ -5015,6 +5192,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/franc": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
+      "integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
+      "dev": true,
+      "dependencies": {
+        "trigram-utils": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/fs-extra": {
@@ -6915,6 +7105,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jieba-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jieba-js/-/jieba-js-1.0.2.tgz",
+      "integrity": "sha512-kLKw1P7bAuFRq5xoBqddx0S8NO0rW7M90GEbYCZ/Xuok4Y8ncRdOrdeZbOZIC4OTGXUZVkPTqw3AGlFvJmf9ww==",
+      "dev": true,
+      "dependencies": {
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.1"
+      }
+    },
     "node_modules/js-md4": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
@@ -7058,6 +7258,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/kuromoji": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/kuromoji/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7097,6 +7317,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
@@ -7310,6 +7536,16 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/n-gram": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/natural-compare": {
@@ -7652,6 +7888,15 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7765,6 +8010,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/preval.macro": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/preval.macro/-/preval.macro-4.0.0.tgz",
+      "integrity": "sha512-sJJnE71X+MPr64CVD2AurmUj4JEDqbudYbStav3L9Xjcqm4AR0ymMm6sugw1mUmfI/7gw4JWA4JXo/k6w34crw==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-preval": "^4.0.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -7864,6 +8118,19 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/raw-body": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+      "integrity": "sha512-WmJJU2e9Y6M5UzTOkHaM7xJGAPQD8PNzx3bAd2+uhZAim6wDk6dAZxPVYLF67XhbR4hmKGh33Lpmh4XWrCH5Mg==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "1",
+        "string_decoder": "0.10"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -8109,6 +8376,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-json-parse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+      "integrity": "sha512-o0JmTu17WGUaUOHa1l0FPGXKBfijbxK6qoHzlkihsDXxzBHvJcA7zgviKR92Xs841rX9pK16unfphLq0/KqX7A==",
+      "dev": true
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -8158,6 +8431,15 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/segmentit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/segmentit/-/segmentit-2.0.3.tgz",
+      "integrity": "sha512-7mn2XL3OdTUQ+AhHz7SbgyxLTaQRzTWQNVwiK+UlTO8aePGbSwvKUzTwE4238+OUY9MoR6ksAg35zl8sfTunQQ==",
+      "dev": true,
+      "dependencies": {
+        "preval.macro": "^4.0.0"
       }
     },
     "node_modules/semver": {
@@ -8369,6 +8651,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -8381,6 +8669,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -8626,6 +8920,20 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/trigram-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+      "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+      "dev": true,
+      "dependencies": {
+        "collapse-white-space": "^2.0.0",
+        "n-gram": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
@@ -8684,6 +8992,27 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ts-type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-3.0.1.tgz",
+      "integrity": "sha512-cleRydCkBGBFQ4KAvLH0ARIkciduS745prkGVVxPGvcRGhMMoSJUB7gNR1ByKhFTEYrYRg2CsMRGYnqp+6op+g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "tslib": ">=2",
+        "typedarray-dts": "^1.0.0"
+      },
+      "peerDependencies": {
+        "ts-toolbelt": "^9.6.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -8865,6 +9194,12 @@
       "engines": {
         "node": ">= 16.0.0"
       }
+    },
+    "node_modules/typedarray-dts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
+      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "5.8.2",
@@ -9201,6 +9536,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordcut": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wordcut/-/wordcut-0.9.1.tgz",
+      "integrity": "sha512-r7wxFbj3ji638nUYvkDWGJmy1kpqBWQ8W0yH/vRb4I2nXHwlJMClgeJN0FtxTEtbN3tnPhMqMuy/kxfXvCU6UA==",
+      "dev": true,
+      "dependencies": {
+        "body": "*",
+        "glob": "^5.0.14",
+        "underscore": "*"
+      },
+      "bin": {
+        "wordcut": "bin/wordcut"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/wordcut/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -9288,6 +9657,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -9349,6 +9727,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     }
   },
@@ -9819,6 +10206,12 @@
         "@babel/plugin-transform-modules-commonjs": "^7.24.7",
         "@babel/plugin-transform-typescript": "^7.24.7"
       }
+    },
+    "@babel/runtime": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
+      "dev": true
     },
     "@babel/template": {
       "version": "7.27.0",
@@ -10571,9 +10964,9 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.2.tgz",
-      "integrity": "sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==",
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.3.tgz",
+      "integrity": "sha512-pyltgilam1QPdn+Zd9gaCfOLcnjMEJ9gV+bTw6/r73INdvzf1ah9zLIJBm+kW7R6IUFIQ1YO+VqZtYxZNWFPEQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
@@ -11237,6 +11630,12 @@
         "@types/tern": "*"
       }
     },
+    "@types/doublearray": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/doublearray/-/doublearray-0.0.32.tgz",
+      "integrity": "sha512-HloTru3I3a55runIVqZX1YBQi2L5A4peNQPh33yshzB4ttt1qHCnHPkuhy9Djy/cTx7i5xJvxItKRPCmvnfpGw==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -11309,6 +11708,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/kuromoji": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/kuromoji/-/kuromoji-0.1.3.tgz",
+      "integrity": "sha512-u+YwX6eJj6Fmm0F5qunsyA+X8HSiyRNNE5ON3itD3tERax4meq9tv+S7bjTMXkPjqbdBGUmH2maGDCuEvpODwg==",
+      "dev": true,
+      "requires": {
+        "@types/doublearray": "*"
+      }
+    },
     "@types/mute-stream": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
@@ -11326,6 +11734,12 @@
       "requires": {
         "undici-types": "~6.20.0"
       }
+    },
+    "@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true
     },
     "@types/resolve": {
       "version": "1.20.2",
@@ -11764,6 +12178,56 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
+    "babel-plugin-preval": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-4.0.0.tgz",
+      "integrity": "sha512-fZI/4cYneinlj2k/FsXw0/lTWSC5KKoepUueS1g25Gb5vx3GrRyaVwxWCshYqx11GEU4mZnbbFhee8vpquFS2w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "babel-plugin-macros": "^2.6.1",
+        "require-from-string": "^2.0.2"
+      },
+      "dependencies": {
+        "babel-plugin-macros": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+          "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "cosmiconfig": "^6.0.0",
+            "resolve": "^1.12.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        }
+      }
+    },
     "babel-preset-current-node-syntax": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
@@ -11802,6 +12266,18 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "body": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+      "integrity": "sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==",
+      "dev": true,
+      "requires": {
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -11856,6 +12332,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==",
       "dev": true
     },
     "call-bind": {
@@ -11965,6 +12447,12 @@
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
+    "collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "dev": true
+    },
     "collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -12013,11 +12501,38 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "continuable-cache": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+      "integrity": "sha512-TF30kpKhTH8AGCG3dut0rdd/19B7Z+qCnrMoBLpyQu/2drZdNrrpcjPEoJeSVsQM+8KmWG5O56oPDjSSUsuTyA==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA==",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
     },
     "create-jest": {
       "version": "29.7.0",
@@ -12032,6 +12547,15 @@
         "jest-config": "^29.7.0",
         "jest-util": "^29.7.0",
         "prompts": "^2.0.1"
+      }
+    },
+    "crlf-normalize": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/crlf-normalize/-/crlf-normalize-1.0.20.tgz",
+      "integrity": "sha512-h/rBerTd3YHQGfv7tNT25mfhWvRq2BBLCZZ80GFarFxf6HQGbpW6iqDL3N+HBLpjLfAdcBXfWAzVlLfHkRUQBQ==",
+      "dev": true,
+      "requires": {
+        "ts-type": ">=2"
       }
     },
     "cross-spawn": {
@@ -12212,6 +12736,12 @@
         "webidl-conversions": "^7.0.0"
       }
     },
+    "doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "dev": true
+    },
     "dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -12255,6 +12785,15 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true
+    },
+    "error": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
+      "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
+      "dev": true,
+      "requires": {
+        "string-template": "~0.2.1"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -12902,6 +13441,15 @@
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
+      }
+    },
+    "franc": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
+      "integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
+      "dev": true,
+      "requires": {
+        "trigram-utils": "^2.0.0"
       }
     },
     "fs-extra": {
@@ -14263,6 +14811,16 @@
         }
       }
     },
+    "jieba-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jieba-js/-/jieba-js-1.0.2.tgz",
+      "integrity": "sha512-kLKw1P7bAuFRq5xoBqddx0S8NO0rW7M90GEbYCZ/Xuok4Y8ncRdOrdeZbOZIC4OTGXUZVkPTqw3AGlFvJmf9ww==",
+      "dev": true,
+      "requires": {
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.1"
+      }
+    },
     "js-md4": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
@@ -14375,6 +14933,28 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuromoji": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+      "dev": true,
+      "requires": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "zlibjs": "^0.3.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -14405,6 +14985,12 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.groupby": {
       "version": "4.6.0",
@@ -14581,6 +15167,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
       "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true
+    },
+    "n-gram": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
       "dev": true
     },
     "natural-compare": {
@@ -14826,6 +15418,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -14899,6 +15497,15 @@
         "parse-ms": "^4.0.0"
       }
     },
+    "preval.macro": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/preval.macro/-/preval.macro-4.0.0.tgz",
+      "integrity": "sha512-sJJnE71X+MPr64CVD2AurmUj4JEDqbudYbStav3L9Xjcqm4AR0ymMm6sugw1mUmfI/7gw4JWA4JXo/k6w34crw==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-preval": "^4.0.0"
+      }
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -14956,6 +15563,16 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "raw-body": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+      "integrity": "sha512-WmJJU2e9Y6M5UzTOkHaM7xJGAPQD8PNzx3bAd2+uhZAim6wDk6dAZxPVYLF67XhbR4hmKGh33Lpmh4XWrCH5Mg==",
+      "dev": true,
+      "requires": {
+        "bytes": "1",
+        "string_decoder": "0.10"
+      }
     },
     "react-is": {
       "version": "18.3.1",
@@ -15128,6 +15745,12 @@
         "isarray": "^2.0.5"
       }
     },
+    "safe-json-parse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+      "integrity": "sha512-o0JmTu17WGUaUOHa1l0FPGXKBfijbxK6qoHzlkihsDXxzBHvJcA7zgviKR92Xs841rX9pK16unfphLq0/KqX7A==",
+      "dev": true
+    },
     "safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -15162,6 +15785,15 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
+      }
+    },
+    "segmentit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/segmentit/-/segmentit-2.0.3.tgz",
+      "integrity": "sha512-7mn2XL3OdTUQ+AhHz7SbgyxLTaQRzTWQNVwiK+UlTO8aePGbSwvKUzTwE4238+OUY9MoR6ksAg35zl8sfTunQQ==",
+      "dev": true,
+      "requires": {
+        "preval.macro": "^4.0.0"
       }
     },
     "semver": {
@@ -15319,6 +15951,12 @@
         "escape-string-regexp": "^2.0.0"
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -15328,6 +15966,12 @@
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
       }
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -15507,6 +16151,16 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
+    "trigram-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+      "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "^2.0.0",
+        "n-gram": "^2.0.0"
+      }
+    },
     "ts-api-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
@@ -15529,6 +16183,24 @@
         "make-error": "^1.3.6",
         "semver": "^7.7.1",
         "yargs-parser": "^21.1.1"
+      }
+    },
+    "ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "peer": true
+    },
+    "ts-type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-3.0.1.tgz",
+      "integrity": "sha512-cleRydCkBGBFQ4KAvLH0ARIkciduS745prkGVVxPGvcRGhMMoSJUB7gNR1ByKhFTEYrYRg2CsMRGYnqp+6op+g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "tslib": ">=2",
+        "typedarray-dts": "^1.0.0"
       }
     },
     "tsconfig-paths": {
@@ -15664,6 +16336,12 @@
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       }
+    },
+    "typedarray-dts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
+      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==",
+      "dev": true
     },
     "typescript": {
       "version": "5.8.2",
@@ -15896,6 +16574,32 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
+    "wordcut": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wordcut/-/wordcut-0.9.1.tgz",
+      "integrity": "sha512-r7wxFbj3ji638nUYvkDWGJmy1kpqBWQ8W0yH/vRb4I2nXHwlJMClgeJN0FtxTEtbN3tnPhMqMuy/kxfXvCU6UA==",
+      "dev": true,
+      "requires": {
+        "body": "*",
+        "glob": "^5.0.14",
+        "underscore": "*"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -15954,6 +16658,12 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
     "yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -15991,6 +16701,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
       "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "dev": true
+    },
+    "zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-frequency",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "description": "Count word frequency in current note within Obsidian",
   "main": "main.js",
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/mts7/obsidian-word-frequency#readme",
   "devDependencies": {
     "@eslint/js": "^9.22.0",
-    "@rollup/plugin-commonjs": "^28.0.2",
+    "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
+import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import typescript from '@rollup/plugin-typescript';
 import json from '@rollup/plugin-json';
 
 export default {
@@ -9,6 +9,14 @@ export default {
         file: 'dist/main.js',
         format: 'cjs',
     },
-    plugins: [commonjs(), json(), resolve(), typescript()],
+    plugins: [
+        resolve(),
+        commonjs({
+            include: /node_modules/,
+            requireReturnsDefault: 'auto',
+        }),
+        json(),
+        typescript()
+    ],
     external: ['obsidian'],
 };

--- a/src/WordFrequencyCounter.ts
+++ b/src/WordFrequencyCounter.ts
@@ -26,7 +26,7 @@ export class WordFrequencyCounter {
     }
 
     calculateWordFrequencies(content: string): [string, number][] {
-        if (!content) {
+        if (content.length === 0) {
             return [];
         }
 

--- a/src/WordFrequencyCounter.ts
+++ b/src/WordFrequencyCounter.ts
@@ -7,6 +7,7 @@ import {
 } from 'obsidian';
 import { EVENT_UPDATE, VIEW_TYPE } from './constants';
 import WordFrequencyPlugin from './main';
+import { segmentText } from './segmentationUtils';
 
 export class WordFrequencyCounter {
     lastActiveEditor: Editor | undefined;
@@ -25,15 +26,11 @@ export class WordFrequencyCounter {
     }
 
     calculateWordFrequencies(content: string): [string, number][] {
-        if (content.length === 0) {
+        if (!content) {
             return [];
         }
 
-        const words = content
-            .toLowerCase()
-            .replace(/[^a-z0-9\s]/g, '')
-            .split(/\s+/)
-            .filter((word): word is string => word.length > 0);
+        const words = segmentText(content);
 
         const wordCounts = new Map<string, number>();
         for (const word of words) {

--- a/src/__tests__/WordFrequencyCounter.test.ts
+++ b/src/__tests__/WordFrequencyCounter.test.ts
@@ -82,6 +82,452 @@ describe('WordFrequencyCounter tests', () => {
 
             expect(result).toEqual([]);
         });
+
+        it('should calculate word frequencies with Russian and separators', () => {
+            const content = 'Привет, мир! Привет. Как дела?';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['привет', 2],
+                ['мир', 1],
+                ['как', 1],
+                ['дела', 1],
+            ]);
+        });
+
+        it('should calculate word frequencies with Spanish and separators (including accents)', () => {
+            const content = 'Hola, mundo! Hola. ¿Qué tal?';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['hola', 2],
+                ['mundo', 1],
+                ['qué', 1],
+                ['tal', 1],
+            ]);
+        });
+
+        it('should calculate word frequencies with French and separators (including accents and apostrophes)', () => {
+            const content = 'Bonjour le monde ! Bonjour. Comment ça va ?';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['bonjour', 2],
+                ['le', 1],
+                ['monde', 1],
+                ['comment', 1],
+                ['ça', 1],
+                ['va', 1],
+            ]);
+        });
+
+        it('should handle mixed languages and special characters', () => {
+            const content = '你好 world! Привет test? Hola 123.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['你好', 1],
+                ['world', 1],
+                ['привет', 1],
+                ['test', 1],
+                ['hola', 1],
+                ['123', 1],
+            ]);
+        });
+
+        it('should handle numbers as words', () => {
+            const content = '123 abc 456 def 123';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['123', 2],
+                ['abc', 1],
+                ['456', 1],
+                ['def', 1],
+            ]);
+        });
+
+        it('should handle leading and trailing special characters and whitespace', () => {
+            const content = '  ~!@#$ word1 word2 %^&* ';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['word1', 1],
+                ['word2', 1],
+            ]);
+        });
+
+        it('should handle consecutive special characters as separators', () => {
+            const content = 'word1 --- word2 *** word3';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['word1', 1],
+                ['word2', 1],
+                ['word3', 1],
+            ]);
+        });
+
+        it('should calculate word frequencies with Korean and punctuation', () => {
+            const content =
+                '안녕하세요, 세계! 좋은 하루 보내세요. 그리고, 나중에 봐요.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['안녕하세요', 1],
+                ['세계', 1],
+                ['좋은', 1],
+                ['하루', 1],
+                ['보내세요', 1],
+                ['그리고', 1],
+                ['나중에', 1],
+                ['봐요', 1],
+            ]);
+        });
+
+        it('should calculate word frequencies with German and punctuation (including ß)', () => {
+            const content =
+                'Hallo Welt! Einen schönen Tag wünsche ich. Und, bis später!';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['hallo', 1],
+                ['welt', 1],
+                ['einen', 1],
+                ['schönen', 1],
+                ['tag', 1],
+                ['wünsche', 1],
+                ['ich', 1],
+                ['und', 1],
+                ['bis', 1],
+                ['später', 1],
+            ]);
+        });
+
+        it('should calculate word frequencies with Swedish and punctuation (including åäö)', () => {
+            const content = 'Hej världen! Ha en bra dag. Och, vi ses snart!';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['hej', 1],
+                ['världen', 1],
+                ['ha', 1],
+                ['en', 1],
+                ['bra', 1],
+                ['dag', 1],
+                ['och', 1],
+                ['vi', 1],
+                ['ses', 1],
+                ['snart', 1],
+            ]);
+        });
+
+        it('should calculate word frequencies with Vietnamese and punctuation (including accented vowels)', () => {
+            const content =
+                'Chào thế giới! Chúc một ngày tốt lành. Và, hẹn gặp lại sau!';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['chào', 1],
+                ['thế', 1],
+                ['giới', 1],
+                ['chúc', 1],
+                ['một', 1],
+                ['ngày', 1],
+                ['tốt', 1],
+                ['lành', 1],
+                ['và', 1],
+                ['hẹn', 1],
+                ['gặp', 1],
+                ['lại', 1],
+                ['sau', 1],
+            ]);
+        });
+
+        it('should correctly count Turkish words', () => {
+            const content = 'Merhaba dünya! Umarım iyi bir gün geçirirsiniz.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['merhaba', 1],
+                ['dünya', 1],
+                ['umarım', 1],
+                ['iyi', 1],
+                ['bir', 1],
+                ['gün', 1],
+                ['geçirirsiniz', 1],
+            ]);
+        });
+
+        it('should correctly count Greek words', () => {
+            const content = 'Γειά σου κόσμε! Ελπίζω να έχεις μια όμορφη μέρα.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['γειά', 1],
+                ['σου', 1],
+                ['κόσμε', 1],
+                ['ελπίζω', 1],
+                ['να', 1],
+                ['έχεις', 1],
+                ['μια', 1],
+                ['όμορφη', 1],
+                ['μέρα', 1],
+            ]);
+        });
+
+        it('should correctly count Finnish words', () => {
+            const content = 'Hei maailma! Toivottavasti sinulla on hyvä päivä.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['hei', 1],
+                ['maailma', 1],
+                ['toivottavasti', 1],
+                ['sinulla', 1],
+                ['on', 1],
+                ['hyvä', 1],
+                ['päivä', 1],
+            ]);
+        });
+
+        it('should correctly count Persian words', () => {
+            const content = 'سلام دنیا! امیدوارم روز خوبی داشته باشید.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['سلام', 1],
+                ['دنیا', 1],
+                ['امیدوارم', 1],
+                ['روز', 1],
+                ['خوبی', 1],
+                ['داشته', 1],
+                ['باشید', 1],
+            ]);
+        });
+
+        it('should correctly count Ukrainian words', () => {
+            const content = 'Привіт, світ! Сподіваюся, ти маєш чудовий день.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['привіт', 1],
+                ['світ', 1],
+                ['сподіваюся', 1],
+                ['ти', 1],
+                ['маєш', 1],
+                ['чудовий', 1],
+                ['день', 1],
+            ]);
+        });
+
+        it('should correctly count Polish words', () => {
+            const content =
+                'Witaj świecie! Mam nadzieję, że masz piękny dzień.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['witaj', 1],
+                ['świecie', 1],
+                ['mam', 1],
+                ['nadzieję', 1],
+                ['że', 1],
+                ['masz', 1],
+                ['piękny', 1],
+                ['dzień', 1],
+            ]);
+        });
+
+        it('should correctly count Hungarian words', () => {
+            const content = 'Helló világ! Remélem, szép napod van.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['helló', 1],
+                ['világ', 1],
+                ['remélem', 1],
+                ['szép', 1],
+                ['napod', 1],
+                ['van', 1],
+            ]);
+        });
+
+        it('should correctly count Amharic words', () => {
+            const content = 'ሰላም ዓለም! ቀኑ ጥሩ ይሁን።';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['ሰላም', 1],
+                ['ዓለም', 1],
+                ['ቀኑ', 1],
+                ['ጥሩ', 1],
+                ['ይሁን', 1],
+            ]);
+        });
+
+        it('should correctly count duplicate words and separate substrings in English', () => {
+            const content = 'useful use usage user used useful useful use';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['useful', 3],
+                ['use', 2],
+                ['usage', 1],
+                ['user', 1],
+                ['used', 1],
+            ]);
+        });
+
+        it('should correctly count duplicate words and separate substrings in Hebrew', () => {
+            const content = 'שלום שלום עולם עולם טוב טוב יום יום טוב';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['טוב', 3],
+                ['שלום', 2],
+                ['עולם', 2],
+                ['יום', 2],
+            ]);
+        });
+
+        it('should correctly count duplicate words and separate substrings in Arabic', () => {
+            const content = 'جميل جمال جميل جمال يوم يوم يوم سعيد';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['يوم', 3],
+                ['جميل', 2],
+                ['جمال', 2],
+                ['سعيد', 1],
+            ]);
+        });
+
+        it('should correctly handle contractions by removing apostrophes in English', () => {
+            const content = "It's a great day! That's why it's important.";
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['its', 2],
+                ['a', 1],
+                ['great', 1],
+                ['day', 1],
+                ['thats', 1],
+                ['why', 1],
+                ['important', 1],
+            ]);
+        });
+
+        it('should correctly remove hyphens from compound words in English', () => {
+            const content = 'Well-being and mother-in-law are important.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['wellbeing', 1],
+                ['and', 1],
+                ['motherinlaw', 1],
+                ['are', 1],
+                ['important', 1],
+            ]);
+        });
+
+        it('should correctly count compound words in German', () => {
+            const content = 'Autobahn Geschwindigkeitsbegrenzung ist wichtig.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['autobahn', 1],
+                ['geschwindigkeitsbegrenzung', 1],
+                ['ist', 1],
+                ['wichtig', 1],
+            ]);
+        });
+
+        it('should correctly handle apostrophe removal in French', () => {
+            const content =
+                "C'est une journée magnifique. L'année commence bien!";
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['cest', 1],
+                ['une', 1],
+                ['journée', 1],
+                ['magnifique', 1],
+                ['lannée', 1],
+                ['commence', 1],
+                ['bien', 1],
+            ]);
+        });
+
+        it('should count words in Arabic', () => {
+            const content = 'أنا أحب اللغة العربية. اللغة العربية جميلة.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['اللغة', 2],
+                ['العربية', 2],
+                ['أنا', 1],
+                ['أحب', 1],
+                ['جميلة', 1],
+            ]);
+        });
+
+        it('should count words in Hebrew', () => {
+            const content = 'אני אוהב ללמוד עברית. עברית שפה יפה.';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['עברית', 2],
+                ['אני', 1],
+                ['אוהב', 1],
+                ['ללמוד', 1],
+                ['שפה', 1],
+                ['יפה', 1],
+            ]);
+        });
+
+        it('should treat all non-punctuation characters as a single word in Chinese (Mandarin)', () => {
+            const content = '你好！世界，你好。你好嗎？123你好';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([['你好世界你好你好嗎123你好', 1]]);
+        });
+
+        it('should treat all non-punctuation characters as a single word in Japanese', () => {
+            const content =
+                'こんにちは、世界！良い一日を。そして、またね123。こんにちは';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['こんにちは世界良い一日をそしてまたね123こんにちは', 1],
+            ]);
+        });
+
+        it('should split Hindi by spaces', () => {
+            const content =
+                'नमस्ते दुनिया! आपका दिन शुभ हो। और, जल्द ही मिलते हैं१२३।नमस्ते';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['ह', 2],
+                ['नमसत', 1],
+                ['दनय', 1],
+                ['आपक', 1],
+                ['दन', 1],
+                ['शभ', 1],
+                ['और', 1],
+                ['जलद', 1],
+                ['मलत', 1],
+                ['ह१२३नमसत', 1],
+            ]);
+        });
+
+        it('should split Thai by spaces', () => {
+            const content =
+                'สวัสดีชาวโลก! ขอให้มีวันที่ดี แล้วพบกันใหม่นะ๑๒๓สวัสดี';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['สวสดชาวโลก', 1],
+                ['ขอใหมวนทด', 1],
+                ['แลวพบกนใหมนะ๑๒๓สวสด', 1],
+            ]);
+        });
+
+        it('should split Tamil by spaces', () => {
+            const content =
+                'வணக்கம் உலகமே! உங்களுக்கு ஒரு நல்ல நாள் அமையட்டும். பிறகு சந்திப்போம்௧௨௩வணக்கம்';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['வணககம', 1],
+                ['உலகம', 1],
+                ['உஙகளகக', 1],
+                ['ஒர', 1],
+                ['நலல', 1],
+                ['நள', 1],
+                ['அமயடடம', 1],
+                ['பறக', 1],
+                ['சநதபபம௧௨௩வணககம', 1],
+            ]);
+        });
+
+        it('should split Burmese by spaces', () => {
+            const content =
+                'မင်္ဂလာပါကမ္ဘာ! သင်သည်ကောင်းသောနေ့ဖြစ်ပါစေသော။ နောက်မှတွေ့မယ်၁၂၃မင်္ဂလာပါ';
+            const result = counter.calculateWordFrequencies(content);
+            expect(result).toEqual([
+                ['မငဂလပကမဘ', 1],
+                ['သငသညကငသနဖစပစသ', 1],
+                ['နကမတမယ၁၂၃မငဂလပ', 1],
+            ]);
+        });
     });
 
     describe('handleActiveLeafChange', () => {

--- a/src/segmentationUtils.ts
+++ b/src/segmentationUtils.ts
@@ -1,0 +1,10 @@
+export function segmentText(content: string): string[] {
+    const normalized = content.toLowerCase().normalize('NFKC');
+
+    const stripped = normalized.replace(/[^\p{L}\p{N}\s]+/gu, '');
+
+    return stripped
+        .trim()
+        .split(/\s+/)
+        .filter((word) => word.length > 0);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ESNext",
-    "types": ["obsidian", "node", "jest"]
+    "types": ["obsidian", "node", "jest"],
   },
-  "include": ["src/**/*", "node_modules/@types/jest/index.d.ts"]
+  "include": ["src/**/*", "types", "node_modules/@types/jest/index.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "target": "ESNext",
     "types": ["obsidian", "node", "jest"],
   },
-  "include": ["src/**/*", "types", "node_modules/@types/jest/index.d.ts"]
+  "include": ["src/**/*", "node_modules/@types/jest/index.d.ts"]
 }


### PR DESCRIPTION
There is now basic support for languages using characters outside of English, especially for languages that use space-separated words. Some languages that have complex word segmentation split incorrectly linguistically, which might need work in the future.

Resolves #27 .
